### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 **Apple Notes MCP Server** is a Model Context Protocol server that enables seamless interaction with Apple Notes through natural language. Create, search, and retrieve notes effortlessly using Claude or other AI assistants! 🎉
 
+<a href="https://glama.ai/mcp/servers/ayr26szokg">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/ayr26szokg/badge" alt="Apple Notes Server MCP server" />
+</a>
+
 ## 🎯 Features
 
 - **Create Notes:** Quickly create new notes with titles, content, and tags 📝


### PR DESCRIPTION
This PR adds a badge for the [Apple Notes MCP Server](https://glama.ai/mcp/servers/ayr26szokg) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/ayr26szokg">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/ayr26szokg/badge" alt="Apple Notes Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.