### PR TITLE
Fix AppleScript execution for multi-line scripts

### DIFF
--- a/src/utils/applescript.ts
+++ b/src/utils/applescript.ts
@@ -2,17 +2,36 @@ import { execSync } from 'child_process';
 import type { AppleScriptResult } from '@/types.js';
 
 /**
+ * Escapes a string for use in a shell single-quoted argument
+ * @param str - The string to escape
+ * @returns The escaped string safe for shell single quotes
+ */
+function escapeForShellSingleQuotes(str: string): string {
+  // In single quotes, only single quotes need escaping: ' -> '\''
+  return str.replace(/'/g, "'\\''");
+}
+
+/**
  * Executes an AppleScript command and returns the result
  * @param script - The AppleScript command to execute
  * @returns Object containing success status and output/error
  */
 export function runAppleScript(script: string): AppleScriptResult {
   try {
-    // Trim and sanitize the script
-    const sanitizedScript = script.trim().replace(/[\r\n]+/g, ' ');
+    // Split script into lines and build multiple -e arguments
+    // osascript requires each -e argument to be a separate line of the script
+    const lines = script
+      .trim()
+      .split(/\r?\n/)
+      .map(line => line.trim())
+      .filter(line => line.length > 0);
+
+    const args = lines
+      .map(line => `-e '${escapeForShellSingleQuotes(line)}'`)
+      .join(' ');
 
     // Execute the AppleScript command
-    const output = execSync(`osascript -e '${sanitizedScript}'`, {
+    const output = execSync(`osascript ${args}`, {
       encoding: 'utf8',
       timeout: 10000 // 10 second timeout
     });


### PR DESCRIPTION
## Summary
- Fixes AppleScript execution that was broken for all multi-line scripts
- The issue caused "syntax error: Expected end of line but found 'tell'" errors when creating notes

## Problem
The previous implementation in `runAppleScript()` replaced all newlines with spaces:
```typescript
const sanitizedScript = script.trim().replace(/[\r\n]+/g, ' ');
```

This resulted in invalid AppleScript like:
```
osascript -e 'tell application "Notes"         tell account "iCloud" ...'
```

AppleScript requires newlines or semicolons between statements - spaces don't work.

## Solution
- Split the script into individual lines
- Pass each line as a separate `-e` argument to `osascript` (the documented way to run multi-line scripts)
- Properly escape single quotes in the script content

```typescript
const lines = script.trim().split(/\r?\n/).map(line => line.trim()).filter(line => line.length > 0);
const args = lines.map(line => `-e '${escapeForShellSingleQuotes(line)}'`).join(' ');
```

## Test plan
- [x] Tested `create-note` - now works correctly
- [x] Tested `search-notes` - works correctly  
- [x] Tested `get-note-content` - works correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)