### PR TITLE
feat: add folder parameter to create-note tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,8 @@ const notesManager = new AppleNotesManager();
 const createNoteSchema = {
   title: z.string().min(1, "Title is required"),
   content: z.string().min(1, "Content is required"),
-  tags: z.array(z.string()).optional()
+  tags: z.array(z.string()).optional(),
+  folder: z.string().optional().describe("Folder name to save the note to (optional)")
 };
 
 const searchSchema = {
@@ -33,9 +34,9 @@ const getNoteSchema = {
 server.tool(
   "create-note",
   createNoteSchema,
-  async ({ title, content, tags = [] }: CreateNoteParams) => {
+  async ({ title, content, tags = [], folder }: CreateNoteParams) => {
     try {
-      const note = notesManager.createNote(title, content, tags);
+      const note = notesManager.createNote(title, content, tags, folder);
       if (!note) {
         return {
           content: [{

--- a/src/services/appleNotesManager.ts
+++ b/src/services/appleNotesManager.ts
@@ -30,17 +30,36 @@ export class AppleNotesManager {
    * @param title - The note title
    * @param content - The note content
    * @param tags - Optional array of tags
+   * @param folder - Optional folder name (Apple Notes folders are flat, use exact folder name e.g., "Work")
    * @returns The created note object or null if creation fails
    */
-  createNote(title: string, content: string, tags: string[] = []): Note | null {
+  createNote(title: string, content: string, tags: string[] = [], folder?: string): Note | null {
     const formattedContent = formatContent(content);
-    const script = `
-      tell application "Notes"
-        tell account "${this.ICLOUD_ACCOUNT}"
-          make new note with properties {name:"${title}", body:"${formattedContent}"}
+    const escapedTitle = title.replace(/"/g, '\\"');
+
+    // Build AppleScript with optional folder targeting
+    // Note: Apple Notes folders are flat at the account level in AppleScript
+    let script: string;
+    if (folder) {
+      const escapedFolder = folder.replace(/"/g, '\\"');
+      script = `
+        tell application "Notes"
+          tell account "${this.ICLOUD_ACCOUNT}"
+            tell folder "${escapedFolder}"
+              make new note with properties {name:"${escapedTitle}", body:"${formattedContent}"}
+            end tell
+          end tell
         end tell
-      end tell
-    `;
+      `;
+    } else {
+      script = `
+        tell application "Notes"
+          tell account "${this.ICLOUD_ACCOUNT}"
+            make new note with properties {name:"${escapedTitle}", body:"${formattedContent}"}
+          end tell
+        end tell
+      `;
+    }
 
     const result = runAppleScript(script);
     if (!result.success) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface CreateNoteParams {
   title: string;
   content: string;
   tags?: string[];
+  folder?: string;
 }
 
 export interface SearchParams {


### PR DESCRIPTION
## Summary
- Add optional `folder` parameter to `create-note` tool for saving notes to specific folders
- Apple Notes folders are flat at the account level in AppleScript, so users specify exact folder name
- Includes proper escaping for title and folder names with special characters

## Test plan
- [ ] Create note without folder parameter (should save to default Notes folder)
- [ ] Create note with `folder: "FolderName"` (should save to specified folder)
- [ ] Test with folder names containing special characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)