### PR TITLE
Add a start up message upon success

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -117,5 +117,6 @@ server.tool(
 );
 
 // Start the server
+console.error("Starting Apple Notes MCP server.");
 const transport = new StdioServerTransport();
 await server.connect(transport);


### PR DESCRIPTION
In README.md, the instruction says upon success "Starting Apple Notes MCP server." will show, but it did not. Turns out there was no success message anywhere. This PR adds the success message. 